### PR TITLE
Fixed installation URL

### DIFF
--- a/README
+++ b/README
@@ -9,11 +9,11 @@ http://ksugita.blog62.fc2.com/blog-entry-8.html
 直接ファイルをダウンロードしてインストール
 
 下記のコマンドを使ってインストール
-M-x install-elisp http://github.com/tomoya/hiwin-mode/raw/master/hiwin.el
-M-x auto-install-from-url http://github.com/tomoya/hiwin-mode/raw/master/hiwin.el
+M-x install-elisp https://raw.github.com/tomoya/hiwin-mode/master/hiwin.el
+M-x auto-install-from-url https://raw.github.com/tomoya/hiwin-mode/master/hiwin.el
 
 もしくは下記のS式を評価してインストール
-(auto-install-from-url "http://github.com/tomoya/hiwin-mode/raw/master/hiwin.el")
-(install-elisp "http://github.com/tomoya/hiwin-mode/raw/master/hiwin.el")
+(auto-install-from-url "https://raw.github.com/tomoya/hiwin-mode/master/hiwin.el")
+(install-elisp "https://raw.github.com/tomoya/hiwin-mode/master/hiwin.el")
 
 のいずれかでご利用下さい。


### PR DESCRIPTION
At now, auto-install-from-url is failed with "http://github.com/...".
We need to change URL to "https://raw.github.com/...".
